### PR TITLE
Fix S3Data deletion session handling

### DIFF
--- a/internal/controller/s3Data_controller.go
+++ b/internal/controller/s3Data_controller.go
@@ -34,7 +34,7 @@ func (r *S3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	logger.Info("Reconciling S3Data...")
 
 	// if the S3Data resource is being deleted, handle deletion
-	if err := r.handleS3DataDeletion(ctx, nil, req); err != nil {
+	if err := r.handleS3DataDeletion(ctx, r.Session, req); err != nil {
 		logger.Error(err, "Failed to handle S3Data deletion")
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
## Summary
- pass the controller session to the deletion handler when reconciling `S3Data`

## Testing
- `make test` *(fails: forbidden to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68431dd276088331927d2298cab81a3f